### PR TITLE
Support Python 2.7

### DIFF
--- a/lruttl/lru.py
+++ b/lruttl/lru.py
@@ -26,11 +26,20 @@ class LRUCache(object):
         item = {'value': value,
                 'expires': expires}
         self.cache[key] = item
+        
+    if hasattr(OrderedDict, 'move_to_end'):
+        # python 3.2+
+        def _move_to_end(self, key):
+            self.cache.move_to_end(key)
+    else:
+        # python 2.7
+        def _move_to_end(self, key):
+            self.cache[key] = self.cache.pop(key)
 
     def get(self, key):
         if key in self.cache:
             now = datetime.now()
-            self.cache.move_to_end(key)  # Mark as most recently used
+            self._move_to_end(key)  # Mark as most recently used
 
             item = self.cache[key]
             if item['expires'] and item['expires'] < now:


### PR DESCRIPTION
Its OrderedDict has no move_to_end() method, so use workaround.
Use if...else when defining method in order to decrease run-time cost.