### PR TITLE
Add __setitem__ with default TTL value

### DIFF
--- a/lruttl/lru.py
+++ b/lruttl/lru.py
@@ -3,8 +3,9 @@ from collections import OrderedDict
 
 
 class LRUCache(object):
-    def __init__(self, size):
+    def __init__(self, size, default_ttl=None):
         self.size = size
+        self.default_ttl = default_ttl
         self.cache = OrderedDict()
 
     def __contains__(self, key):
@@ -12,6 +13,9 @@ class LRUCache(object):
 
     def __getitem__(self, key):
         return self.get(key)
+    
+    def __setitem__(self, key, value):
+        self.set(key, value, self.default_ttl)
 
     def set(self, key, value, ttl=None):
         if len(self.cache) == self.size:


### PR DESCRIPTION
Not sure if this is good implementation.
Probably default TTL should also be applied when .set() is called without specifying TTL; in such case we will need to use some sentinel for default argument value rather than None, so that it would be possible to override default non-None.
Or use `0` as "does not expire" and use None for default.